### PR TITLE
WIP layout for news detail page

### DIFF
--- a/_includes/list_news.html
+++ b/_includes/list_news.html
@@ -3,7 +3,14 @@
 <div class="entry-item">
     <h3 class="entry-title">{{post.title}}</h3>
     <p class="entry-meta">{{ post.date | date_to_long_string }}</p>
-    {{ post.content }}
+    {% if post.summary %}
+        {{ post.summary | markdownify }}
+
+        <p><a href="{{ site.baseurl }}{{ post.url }}">Read more</a></p>
+    {% else %}
+        {{ post.content }}
+    {% endif %}
+
 </div>
 {% endfor %}
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,11 @@
+---
+layout: default
+---
+
+<p class="entry-meta">{{ page.date | date_to_long_string }}</p>
+
+<h1 class="page-title">{{ page.title }}</h1>
+
+
+{{ content }}
+

--- a/_posts/news/2018-04-22-chi2018.md
+++ b/_posts/news/2018-04-22-chi2018.md
@@ -1,0 +1,16 @@
+---
+layout: post
+title: "KIXLAB at CHI 2018"
+date: 2018-04-22 00:00:00
+author: Admin
+categories: news
+summary: Several members from KIXLAB are attending CHI 2018 and presenting their work. Please see the full post for details.
+---
+
+The [Tool Diversity](https://dl.acm.org/authorize?N43044) paper by Jean Y. Song, Raymond Fok, Alan Lundgard, Fan Yang, Juho Kim, and Walter S. Lasecki wins a Best Student Paper Honorable Mention Award at [IUI2018](http://iui.acm.org/2018/).
+
+The [Tool Diversity](https://dl.acm.org/authorize?N43044) paper by Jean Y. Song, Raymond Fok, Alan Lundgard, Fan Yang, Juho Kim, and Walter S. Lasecki wins a Best Student Paper Honorable Mention Award at [IUI2018](http://iui.acm.org/2018/).
+
+The [Tool Diversity](https://dl.acm.org/authorize?N43044) paper by Jean Y. Song, Raymond Fok, Alan Lundgard, Fan Yang, Juho Kim, and Walter S. Lasecki wins a Best Student Paper Honorable Mention Award at [IUI2018](http://iui.acm.org/2018/).
+
+The [Tool Diversity](https://dl.acm.org/authorize?N43044) paper by Jean Y. Song, Raymond Fok, Alan Lundgard, Fan Yang, Juho Kim, and Walter S. Lasecki wins a Best Student Paper Honorable Mention Award at [IUI2018](http://iui.acm.org/2018/).


### PR DESCRIPTION
Posts can now specify a `summary` (can use markdown). If a post has a summary, on the homepage that is shown instead of the full content, along with a link to the detail page.

Need to add proper content before merging to master.