### PR TITLE
HOW TO: Per-project page

### DIFF
--- a/_includes/list_projects.html
+++ b/_includes/list_projects.html
@@ -2,13 +2,26 @@
     {% for project in include.projects limit:include.limit %}
     <div class="project">
         <div class="project-text">
-            <h2 class="project-title">{{project.title}}</h2>
-            {% if project.website %}
+            <h2 class="project-title">
+                {% if project.single_page %}<a href="{{project.url}}">{{project.title}}</a>
+                {% else %}{{project.title}}{% endif %}
+            </h2>
+            
+            <p>
+                {% if project.single_page %}
+                    {{project.excerpt | remove: '<p>' | remove: '</p>'}}
+
+                    {% if project.excerpt != project.content %}
+                    <a href="{{project.url}}" class="read-more-btn">Read more</a>
+                    {% endif %}
+                {% else %}
+                    {{project.content}}
+                {% endif %}
+            </p>
+
+            <!--{% if project.website %}
             <p><a href="{{project.website}}" class="link-button">Project website</a></p>
-            {% endif %}
-            
-            {{project.content}}
-            
+            {% endif %}-->
         </div>
 
         <div class="project-image">

--- a/_includes/list_recent_projects.html
+++ b/_includes/list_recent_projects.html
@@ -2,7 +2,10 @@
     <div class="area-item" onClick="this.children[0].children[1].children[0].click()">
         <div class="media area-blurp">
           <div class="media-image project-image" style="background-image: url({{ "/assets/img/projects/" | prepend: site.baseurl }}{{ project.img }});"></div>
-          <div class="media-title project-title"><a href="{{ site.baseurl }}/projects/">{{project.short_title}}</a></div>
+          <div class="media-title project-title">
+              {% if project.single_page %}<a href="{{project.url}}">{{project.short_title}}</a>
+              {% else %}<a href="{{ site.baseurl }}/projects/">{{project.short_title}}</a>{% endif %}
+            </div>
           <p class="project-description">{{project.oneline}}</p>
         </div>
     </div>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -1,0 +1,27 @@
+---
+layout: default
+---
+
+<div class="single-project">
+  <h1 class="page-title">{{ page.title }}</h1>
+
+  <p class="entry-meta">{{ page.authors }}</p>
+
+  <div class="project-content">
+    <div class="project-meta">
+      <ul class="links-list">
+        {% if page.website %}
+        <li class="external"><a href="{{page.website}}">Project website</a></li>
+        {% endif %}
+
+        {% for line in page.sidebar %}
+        <li>{{line | markdownify | remove: '<p>' | remove: '</p>'}}</li>
+        {% endfor %}
+      </ul>
+    </div>
+
+    <div class="project-text">
+    {{ content }}
+    </div>
+  </div>
+</div>

--- a/_posts/projects/2016-07-01-summer-interns-2016.markdown
+++ b/_posts/projects/2016-07-01-summer-interns-2016.markdown
@@ -1,5 +1,5 @@
 ---
-layout: projects
+layout: project
 title:  "2016 Summer Intern Projects"
 date:   2016-07-01 00:00:00
 author: Admin

--- a/_posts/projects/2016-12-01-xproject.markdown
+++ b/_posts/projects/2016-12-01-xproject.markdown
@@ -1,5 +1,5 @@
 ---
-layout: projects
+layout: project
 title:  "Improving Government Transparency with Social Computing"
 date:   2016-12-01 00:00:00
 author: Admin

--- a/_posts/projects/2017-01-25-recipescape.markdown
+++ b/_posts/projects/2017-01-25-recipescape.markdown
@@ -1,5 +1,5 @@
 ---
-layout: projects
+layout: project
 title:  "RecipeScape: Mining and Analyzing Diverse Processes in Cooking&nbsp;Recipes"
 short_title: "RecipeScape"
 oneline: "Mining and Analyzing Diverse Processes in Cooking Recipes"
@@ -9,8 +9,21 @@ categories:
 - projects
 img: 2017-recipescape.png
 website: http://recipescape.kixlab.org
-desc: "Enhancing video lectures; learner engagement; affinity between politicians"
+single_page: true
+authors: Minsuk Chang, Leonore Guillain, Hyeungshik Jung, Vivian Hare, Juho Kim, Maneesh Agrawala
+sidebar:
+- "_RecipeScape: An Interactive Tool for Analyzing Cooking Instructions at Scale_. CHI 2018. [PDF](https://recipescape.kixlab.org/RecipeScape_CHI_2018__Camera_Ready_.pdf). [ACM Citation](https://dl.acm.org/citation.cfm?id=3174025)"
+- "[Video preview](https://youtu.be/PslAojnaKnQ)"
 ---
-In this research, we explore how analyzing cooking recipes in aggregate and in scale helps discovering the core values in the collective cooking culture, and answer fundamental questions like ‘‘what makes a chocolate chip cookie a chocolate chip cookie’’. Aspiring cooks, professional chefs and cooking hobbyists share their recipes online resulting in thousands of different procedural instructions towards a shared goal. We introduce RecipeScape, a prototype interface which supports visually querying, browsing and comparing cooking recipes at scale. We also present the underlying computational pipeline of RecipeScape that scrapes recipes online, extracts their structural semantics from ingredient and instruction information, constructs a procedural graphical representation, and computes similarity between pairs of recipes.
+We explore how analyzing cooking recipes in aggregate and in scale helps discovering the core values in the collective cooking culture, and answer fundamental questions like ‘‘what makes a chocolate chip cookie a chocolate chip cookie’’.
+Aspiring cooks, professional chefs, and cooking hobbyists share their recipes online resulting in thousands of different procedural instructions towards a shared goal.
+We introduce RecipeScape, a prototype interface which supports visually querying, browsing and comparing cooking recipes at scale.
 
-Joint research project with [Stanford University](http://brown.stanford.edu/)
+We also present the underlying computational pipeline of RecipeScape that scrapes recipes online, extracts their structural semantics from ingredient and instruction information, constructs a procedural graphical representation, and computes similarity between pairs of recipes.
+
+Joint research project with [Stanford University](http://brown.stanford.edu/).
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/PslAojnaKnQ?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+
+![RecipeScape with RecipeMap, RecipeDeck, and RecipeStat]({{"/assets/img/projects/2017-recipescape.png" | absolute_url}})
+<span class="caption">RecipeScape with RecipeMap, RecipeDeck, and RecipeStat</span>

--- a/_posts/projects/2017-02-01-winter-interns-2017.markdown
+++ b/_posts/projects/2017-02-01-winter-interns-2017.markdown
@@ -1,5 +1,5 @@
 ---
-layout: projects
+layout: project
 title:  "Winter 2017 Intern Projects"
 date:   2017-02-28 00:00:00
 author: Admin

--- a/_posts/projects/2017-04-12-rally.markdown
+++ b/_posts/projects/2017-04-12-rally.markdown
@@ -1,6 +1,6 @@
 ---
-layout: projects
-title:  "Rally(아, 쫌!): A Data-driven Community Petition Platform"
+layout: project
+title:  "Rally (아, 쫌!): A Data-driven Community Petition Platform"
 date:   2017-04-12 00:00:00
 author: Admin
 categories:

--- a/_posts/projects/2017-08-01-cdq.markdown
+++ b/_posts/projects/2017-08-01-cdq.markdown
@@ -1,5 +1,5 @@
 ---
-layout: projects
+layout: project
 title:  "Collaborative Dynamic Query"
 date:   2017-08-01 00:00:00
 author: Admin

--- a/_posts/projects/2017-08-01-microngo.markdown
+++ b/_posts/projects/2017-08-01-microngo.markdown
@@ -1,5 +1,5 @@
 ---
-layout: projects
+layout: project
 title:  "Micro-NGO: An Online Social Activism Platform with a Mediator Bot"
 date:   2017-08-01 00:00:00
 author: Admin

--- a/_posts/projects/2017-08-10-iotproject.markdown
+++ b/_posts/projects/2017-08-10-iotproject.markdown
@@ -1,5 +1,5 @@
 ---
-layout: projects
+layout: project
 title:  "Enhancing Informal Communication in the Workplace with Online and Physical Data"
 short_title: "Data-Driven Personas"
 oneline: "Building data-driven personas in smart space by analyzing interactions at scale"

--- a/_posts/projects/2017-08-11-exprgram.markdown
+++ b/_posts/projects/2017-08-11-exprgram.markdown
@@ -1,5 +1,5 @@
 ---
-layout: projects
+layout: project
 title:  "Exprgram: Language Learning Interface for Development of Pragmatic Competence through Learnersourcing Video Annotation"
 short_title: "Exprgram"
 oneline: "Language Learning Interface for Development of Pragmatic Competence through Learnersourcing Video Annotation"

--- a/_posts/projects/2017-08-11-flagship_ai.markdown
+++ b/_posts/projects/2017-08-11-flagship_ai.markdown
@@ -1,5 +1,5 @@
 ---
-layout: projects
+layout: project
 title:  "Interaction Techniques for Intelligent Agents Powered by Large-Scale Conversation Mining"
 short_title: "Interaction Techniques for Intelligent Agents"
 oneline: "Powered by Large-Scale Conversation Mining"

--- a/_posts/projects/2017-08-31-summer-interns-2017.md
+++ b/_posts/projects/2017-08-31-summer-interns-2017.md
@@ -1,5 +1,5 @@
 ---
-layout: projects
+layout: project
 title:  "Summer 2017 Internship Projects"
 date:   2017-08-31 00:00:00
 author: Admin

--- a/_posts/projects/2017-12-15-fall-2017-theses.md
+++ b/_posts/projects/2017-12-15-fall-2017-theses.md
@@ -1,5 +1,5 @@
 ---
-layout: projects
+layout: project
 title:  "Fall 2017 Undergraduate Theses"
 date:   2017-12-15 00:00:00
 author: Admin

--- a/_posts/projects/2017-12-29-suggestbot.markdown
+++ b/_posts/projects/2017-12-29-suggestbot.markdown
@@ -1,5 +1,5 @@
 ---
-layout: projects
+layout: project
 title:  "Crowdsourcing Techniques for Annotating Context, Emotion, and Intention on Dialog Videos"
 short_title: "Crowdsourcing for Annotating Dialog Videos"
 oneline: "Building online crowdsourcing platform to collect contextual, emotional, and intentional labels on dialog videos"

--- a/assets/style/_projects.scss
+++ b/assets/style/_projects.scss
@@ -1,6 +1,7 @@
 @charset "UTF-8";
 
 .project-list {
+
     .project-title {
         font-weight: 500;
         line-height: 2rem;
@@ -42,9 +43,84 @@
 
             padding: .5rem 0 .5rem calc(1.5rem - 3px);
 
+            line-height: 1.5rem;
+
             .project-title {
                 margin-top: 0;
             }
+        }
+    }
+}
+
+.single-project {
+    .page-title {
+        margin-bottom: 1rem;
+    }
+    .entry-meta {
+        margin-bottom: 1rem;
+    }
+
+    .project-text {
+        img {
+            max-width: 100%;
+        }
+
+        .caption {
+            font-weight: bold;
+            font-size: .85em;
+        }
+
+        iframe {
+            margin: 1.5rem 0;
+        }
+    }
+
+    .project-content {
+        display: flex;
+        flex-direction: column;
+
+        @media(min-width: 600px) {
+            flex-direction: row;
+        }
+
+        .project-meta {
+            font-size: .9em;
+            margin-bottom: 2*$spacing;
+
+            @media(min-width: 600px) {
+                order: 2;
+                flex: 20;
+                margin-left: 3*$spacing;
+                border-top: 1px solid #333;
+                padding-top: .5em;
+            }
+        }
+        .project-text {
+            flex: (69-20);
+        }
+    }
+}
+
+.links-list {
+    margin-left: .5em;
+    line-height: 1.5;
+
+    li {
+        text-indent: -1em;
+        margin-left: 1em;
+        &:before {
+            content: "\25A0";
+            width: 1em;
+            text-align: center;
+            display: inline-block;
+        }
+
+        &.external:before {
+            content: "\2197";
+        }
+
+        &.document:before {
+            content: "\2630";
         }
     }
 }

--- a/assets/style/_typography.scss
+++ b/assets/style/_typography.scss
@@ -54,6 +54,11 @@ a.link-button {
     }
 }
 
+.read-more-btn {
+    text-transform: uppercase;
+    font-size: .85em;
+}
+
 /* Headlines */
 h1, h2, h3, h4 {
     line-height: 2rem;
@@ -93,6 +98,7 @@ h2 {
     font-size: 0.875em;
     color: #818181;
     margin: 0;
+    font-style: italic;
 
     & + p {
         margin-top: 0;


### PR DESCRIPTION
I prepared an example how to use the single-page project template. We just use the `projects` posts that are also used for the list of projects, but optionally we can enable their single page which gets its own URL.

I put some comments in the commit below to explain parts of the yml file.

Some ideas of what content you can add:

- Abstract
- Video (video preview, demo video, talk video)
- Paper(s) with links to PDF and Citations
- Code
- Data
- Screenshots / figures
- Demo
- Slides / posters used in conference 
- Media / News coverage
